### PR TITLE
Guard against linker script when built as a dep

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "thumbv7em-none-eabi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ license = "0BSD"
 repository = "https://github.com/samcrow/stm32_i2s"
 keywords = ["i2s", "audio", "embedded"]
 categories = ["embedded", "hardware-support", "multimedia::audio", "no-std"]
-# Build script for examples only
-build = "build.rs"
 
 [dependencies]
 vcell = "0.1.3"

--- a/build.rs
+++ b/build.rs
@@ -7,15 +7,18 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("memory.x"))
-        .unwrap();
-    println!("cargo:rustc-link-search={}", out.display());
+    // Guard against including the linker script when building as a library dependency
+    if env::var_os("CARGO_PRIMARY_PACKAGE").and(env::var_os("CARGO_BIN_NAME")).is_some() {
+        // Put the linker script somewhere the linker can find it
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
 
-    // Only re-run the build script when memory.x is changed,
-    // instead of when any part of the source code changes.
-    println!("cargo:rerun-if-changed=memory.x");
+        // Only re-run the build script when memory.x is changed,
+        // instead of when any part of the source code changes.
+        println!("cargo:rerun-if-changed=memory.x");
+    }
 }

--- a/memory.x
+++ b/memory.x
@@ -4,3 +4,8 @@ MEMORY
   FLASH : ORIGIN = 0x08000000, LENGTH = 1024K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* NOTE Do NOT modify `_stack_start` unless you know what you are doing */
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);


### PR DESCRIPTION
Adds a check for both `CARGO_PRIMARY_PACKAGE` and `CARGO_BIN_NAME` in the build script before injecting the linker script `memory.x`. This should prevent it from being included when building this crate as a dependency.

Without this guard, this crate's `memory.x` will be picked up by the linker when building an dependant crate, overriding that crate's own `memory.x`.

I verified this behaviour using a freshly-generated copy of [knurling-rs/app-template](https://github.com/knurling-rs/app-template) configured for an `stm32f446` which only has 128K of RAM. I included `stm32f4xx-hal` with the `i2s` feature enabled, thus pulling in this crate, `stm32_i2s_v12x`. The `memory.x` in this crate specifies 256K of RAM.

Without this change, the `hello` example gets generated with a stack starting at `0x2003fbc8`, leading to hardware exceptions (and confusion 🤣). After this change, the stack correctly starts at `0x2001fbc8`. I confirmed this both by printing the `.data` section and the vector table.