### PR TITLE
Dual i2s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stm32_i2s_v12x"
-version = "0.2.0"
+version = "0.3.0-alpha"
 authors = ["Sam Crow <scrow@eng.ucsd.edu>"]
 edition = "2018"
 description = "Driver for I2S communication (using SPI peripherals) for some STM32 microcontrollers"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1511,6 +1511,58 @@ where
     }
 }
 
+/// # Common functions for main
+///
+/// These interrupt functions can be used for transmission and reception.
+impl<I, M, ANYMODE> DualI2s<I, (M, ANYMODE)>
+where
+    I: DualInstance,
+    M: ActiveMode,
+{
+    /// Enables the interrupt signal output for an event
+    pub fn main_listen(&mut self, event: Event) {
+        self.main_registers().cr2.modify(|_, w| match event {
+            Event::TransmitEmtpy => w.txeie().not_masked(),
+            Event::ReceiveNotEmpty => w.rxneie().not_masked(),
+            Event::Error => w.errie().not_masked(),
+        })
+    }
+    /// Disables the interrupt signal output for an event
+    pub fn main_unlisten(&mut self, event: Event) {
+        self.main_registers().cr2.modify(|_, w| match event {
+            Event::TransmitEmtpy => w.txeie().masked(),
+            Event::ReceiveNotEmpty => w.rxneie().masked(),
+            Event::Error => w.errie().masked(),
+        })
+    }
+}
+
+/// # Common functions for ext
+///
+/// These interrupt functions can be used for transmission and reception.
+impl<I, ANYMODE, M> DualI2s<I, (ANYMODE, M)>
+where
+    I: DualInstance,
+    M: ActiveMode,
+{
+    /// Enables the interrupt signal output for an event
+    pub fn ext_listen(&mut self, event: Event) {
+        self.ext_registers().cr2.modify(|_, w| match event {
+            Event::TransmitEmtpy => w.txeie().not_masked(),
+            Event::ReceiveNotEmpty => w.rxneie().not_masked(),
+            Event::Error => w.errie().not_masked(),
+        })
+    }
+    /// Disables the interrupt signal output for an event
+    pub fn ext_unlisten(&mut self, event: Event) {
+        self.ext_registers().cr2.modify(|_, w| match event {
+            Event::TransmitEmtpy => w.txeie().masked(),
+            Event::ReceiveNotEmpty => w.rxneie().masked(),
+            Event::Error => w.errie().masked(),
+        })
+    }
+}
+
 /// Errors that can occur when transmitting
 #[derive(Debug)]
 pub enum TransmitError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,7 +887,7 @@ where
     pub fn ext_configure_slave_transmit<F>(
         self,
         config: SlaveConfig<F>,
-    ) -> DualI2s<I, (TransmitMode<F>, ANYMODE)>
+    ) -> DualI2s<I, (ANYMODE, TransmitMode<F>)>
     where
         F: DataFormat,
     {
@@ -899,7 +899,7 @@ where
         );
         DualI2s {
             instance: self.instance,
-            frame_formats: (config.frame_format, self.frame_formats.1),
+            frame_formats: (self.frame_formats.0, config.frame_format),
             _modes: PhantomData,
         }
     }
@@ -908,7 +908,7 @@ where
     pub fn ext_configure_slave_receive<F>(
         self,
         config: SlaveConfig<F>,
-    ) -> DualI2s<I, (ReceiveMode<F>, ANYMODE)>
+    ) -> DualI2s<I, (ANYMODE, TransmitMode<F>)>
     where
         F: DataFormat,
     {
@@ -920,7 +920,7 @@ where
         );
         DualI2s {
             instance: self.instance,
-            frame_formats: (config.frame_format, self.frame_formats.1),
+            frame_formats: (self.frame_formats.0, config.frame_format),
             _modes: PhantomData,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub enum Channel {
 /// Events with associated interrupts that can be enabled
 pub enum Event {
     /// The transmit data register is empty, and a sample can be written
-    TransmitEmtpy,
+    TransmitEmpty,
     /// The receive data register is not empty, and a sample can be read
     ReceiveNotEmpty,
     /// An error has occurred
@@ -626,7 +626,7 @@ where
     /// Enables the interrupt signal output for an event
     pub fn listen(&mut self, event: Event) {
         self.registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().not_masked(),
+            Event::TransmitEmpty => w.txeie().not_masked(),
             Event::ReceiveNotEmpty => w.rxneie().not_masked(),
             Event::Error => w.errie().not_masked(),
         })
@@ -634,7 +634,7 @@ where
     /// Disables the interrupt signal output for an event
     pub fn unlisten(&mut self, event: Event) {
         self.registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().masked(),
+            Event::TransmitEmpty => w.txeie().masked(),
             Event::ReceiveNotEmpty => w.rxneie().masked(),
             Event::Error => w.errie().masked(),
         })
@@ -1522,7 +1522,7 @@ where
     /// Enables the interrupt signal output for an event
     pub fn main_listen(&mut self, event: Event) {
         self.main_registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().not_masked(),
+            Event::TransmitEmpty => w.txeie().not_masked(),
             Event::ReceiveNotEmpty => w.rxneie().not_masked(),
             Event::Error => w.errie().not_masked(),
         })
@@ -1530,7 +1530,7 @@ where
     /// Disables the interrupt signal output for an event
     pub fn main_unlisten(&mut self, event: Event) {
         self.main_registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().masked(),
+            Event::TransmitEmpty => w.txeie().masked(),
             Event::ReceiveNotEmpty => w.rxneie().masked(),
             Event::Error => w.errie().masked(),
         })
@@ -1548,7 +1548,7 @@ where
     /// Enables the interrupt signal output for an event
     pub fn ext_listen(&mut self, event: Event) {
         self.ext_registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().not_masked(),
+            Event::TransmitEmpty => w.txeie().not_masked(),
             Event::ReceiveNotEmpty => w.rxneie().not_masked(),
             Event::Error => w.errie().not_masked(),
         })
@@ -1556,7 +1556,7 @@ where
     /// Disables the interrupt signal output for an event
     pub fn ext_unlisten(&mut self, event: Event) {
         self.ext_registers().cr2.modify(|_, w| match event {
-            Event::TransmitEmtpy => w.txeie().masked(),
+            Event::TransmitEmpty => w.txeie().masked(),
             Event::ReceiveNotEmpty => w.rxneie().masked(),
             Event::Error => w.errie().masked(),
         })


### PR DESCRIPTION
Hi, i started to write a HAL to handle extended I2S. My current idea is to have a object that encapsulate the SPI peripheral and it's corresponding I2SEXT. It's because I2SEXT share pins with a SPI peripherals, so it can't be build independently.